### PR TITLE
Fix bug corrupt sln when has dependencies

### DIFF
--- a/src/slnStartupProjectLibrary/Parser.cs
+++ b/src/slnStartupProjectLibrary/Parser.cs
@@ -27,7 +27,7 @@ namespace slnStartupProjectLibrary
             }
             try
             {
-                Regex projectRegex = new Regex(@"(Project\(.*?EndProject)", RegexOptions.Singleline);
+                Regex projectRegex = new Regex(@"(\bProject\b\(.*?\bEndProject\b)", RegexOptions.Singleline);
                 MatchCollection projectMatches = projectRegex.Matches(text);
                 if (projectMatches.Count == 0)
                     throw new Exception("Could not find any projects in the solution");

--- a/src/slnStartupProjectLibrary/Parser.cs
+++ b/src/slnStartupProjectLibrary/Parser.cs
@@ -51,8 +51,12 @@ namespace slnStartupProjectLibrary
             try
             {
                 string newSln = text.Substring(0, projectsStartOffset);
+                List<string> projectString = new List<string>();
                 foreach (Project project in projects)
-                    newSln += project.CDATA + Environment.NewLine;
+                {
+                    projectString.Add(project.CDATA);
+                }
+                newSln += string.Join(Environment.NewLine, projectString.ToArray());
                 newSln += text.Substring(projectsEndOffset, text.Length - projectsEndOffset);
                 File.WriteAllText(slnFilename, newSln, fileEncoding);
             }

--- a/src/slnStartupProjectLibrary/Parser.cs
+++ b/src/slnStartupProjectLibrary/Parser.cs
@@ -15,7 +15,19 @@ namespace slnStartupProjectLibrary
             int projectsStartOffset = -1;
             int projectsEndOffset = -1;
             List<Project> projects = new List<Project>();
-            Encoding fileEncoding = new UTF8Encoding(false); // No Byte Order Mark (BOM)
+
+            /* check if the solution file has BOM */
+            bool hasBOM = false;
+            using(FileStream fs = new FileStream(slnFilename, FileMode.Open))
+            {
+                byte[] bits = new byte[3];
+                fs.Read(bits, 0, 3);
+                if (bits[0] == 0xEF && bits[1] == 0xBB && bits[2] == 0xBF)
+                {
+                    hasBOM = true;
+                }
+            }
+            Encoding fileEncoding = new UTF8Encoding(hasBOM);
 
             try
             {


### PR DESCRIPTION
I found the following bugs and fix them.

- SetStartupProject corrupts a solution file which has project dependencies.
- If SetStartupProject is called, a solution file's size is one byte larger than before.
- BOM is removed even if the original solution has it.

I implement the unittests to check whether the bugs are fixed.
I will create another pull request for that.
