### PR TITLE
change the output directories to directories which is not under version control

### DIFF
--- a/projects/pushNugets.bat
+++ b/projects/pushNugets.bat
@@ -1,13 +1,13 @@
 @echo off
 
 cd vs2013\slnStartupProjectLibrary
-nuget pack -prop Platform=AnyCPU slnStartupProjectLibrary.csproj
+nuget pack slnStartupProjectLibrary.csproj -Build -prop Platform=AnyCPU -prop Configuration=Release
 nuget push slnStartupProjectLibrary.1.1.1.0.nupkg
 
 cd ..\..
 
 cd vs2013\slnStartupProject
-nuget pack -prop Platform=AnyCPU slnStartupProject.csproj
+nuget pack slnStartupProject.csproj -Build -prop Platform=AnyCPU -prop Configuration=Release
 nuget push slnStartupProject.1.1.1.0.nupkg
 
 cd ..\..

--- a/projects/vs2013/slnStartupProject/packages.config
+++ b/projects/vs2013/slnStartupProject/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="slnStartupProjectLibrary" version="1.1.0.0" targetFramework="net35" />
-</packages>

--- a/projects/vs2013/slnStartupProject/slnStartupProject.csproj
+++ b/projects/vs2013/slnStartupProject/slnStartupProject.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/projects/vs2013/slnStartupProjectLibrary/slnStartupProjectLibrary.csproj
+++ b/projects/vs2013/slnStartupProjectLibrary/slnStartupProjectLibrary.csproj
@@ -22,7 +22,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\Debug</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -30,7 +30,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\Release</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
As mentioned #8, I'm implementing a Visual Studio Plugin using this library.

When the development, it is not convenient to overwrite the version controlled files whenever compling
because I need to exclude slnStartupProjectLibrary.dll whenever committing the files to the repositoy

It is very tedious.

So I will change the output directories to the directories which is not under version control.
I think the version controlled files should be updated only when releasing the files.