### PR TITLE
Unitest for dependency bug with vs2013 project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ projects/vs2008/slnStartupProject/obj/
 projects/vs2008/slnStartupProjectLibrary/obj/
 projects/vs2013/slnStartupProject/obj/
 projects/vs2013/slnStartupProjectLibrary/obj/
+/tests/data/ExampleProject/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ projects/vs2008/slnStartupProjectLibrary/obj/
 projects/vs2013/slnStartupProject/obj/
 projects/vs2013/slnStartupProjectLibrary/obj/
 /tests/data/ExampleProject/.vs
+*.db

--- a/projects/slnStartupProject.sln
+++ b/projects/slnStartupProject.sln
@@ -7,21 +7,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "slnStartupProject", "vs2013
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "slnStartupProjectLibrary", "vs2013\slnStartupProjectLibrary\slnStartupProjectLibrary.csproj", "{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}"
 EndProject
-
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "slnStartupProjectUnitTest", "vs2013\slnStartupProjectUnitTest\slnStartupProjectUnitTest.csproj", "{BBE2A7B3-5A0F-4326-AD58-BD6D3F7B956C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4DB074A8-D175-41C7-BAAF-00F2F73C970E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4DB074A8-D175-41C7-BAAF-00F2F73C970E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4DB074A8-D175-41C7-BAAF-00F2F73C970E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4DB074A8-D175-41C7-BAAF-00F2F73C970E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A01E2F2D-CCD1-46B4-82D7-EB4C7A503004}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBE2A7B3-5A0F-4326-AD58-BD6D3F7B956C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBE2A7B3-5A0F-4326-AD58-BD6D3F7B956C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBE2A7B3-5A0F-4326-AD58-BD6D3F7B956C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBE2A7B3-5A0F-4326-AD58-BD6D3F7B956C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/projects/vs2013/slnStartupProjectUnitTest/packages.config
+++ b/projects/vs2013/slnStartupProjectUnitTest/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.6.1" targetFramework="net35" />
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net35" />
+</packages>

--- a/projects/vs2013/slnStartupProjectUnitTest/slnStartupProjectUnitTest.csproj
+++ b/projects/vs2013/slnStartupProjectUnitTest/slnStartupProjectUnitTest.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{BBE2A7B3-5A0F-4326-AD58-BD6D3F7B956C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>slnStartupProjectUnitTest</RootNamespace>
+    <AssemblyName>slnStartupProjectUnitTest</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.6.1\lib\net35\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Xml.Linq">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data.DataSetExtensions">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\src\slnStartupProjectUnitTest\Properties\AssemblyInfo.cs">
+      <Link>AssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\..\..\src\slnStartupProjectUnitTest\UnitTest.cs">
+      <Link>UnitTest.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\slnStartupProjectLibrary\slnStartupProjectLibrary.csproj">
+      <Project>{a01e2f2d-ccd1-46b4-82d7-eb4c7a503004}</Project>
+      <Name>slnStartupProjectLibrary</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/slnStartupProjectUnitTest/Properties/AssemblyInfo.cs
+++ b/src/slnStartupProjectUnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("slnStartupProjectUnitTest")]
+[assembly: AssemblyDescription("A .NET library to set the default StartUp project of a Visual Studio solution file")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("iVoltage")]
+[assembly: AssemblyProduct("sln StartUp Project UnitTest")]
+[assembly: AssemblyCopyright("Copyright © Michel Courtine 2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: ComVisible(false)]
+[assembly: Guid("bbe2a7b3-5a0f-4326-ad58-bd6d3f7b956c")]
+[assembly: AssemblyVersion("1.1.1.0")]
+[assembly: AssemblyFileVersion("1.1.1.0")]

--- a/src/slnStartupProjectUnitTest/UnitTest.cs
+++ b/src/slnStartupProjectUnitTest/UnitTest.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+using NUnit.Framework;
+using slnStartupProjectLibrary;
+
+namespace slnStartupUnitTest
+{
+    [TestFixture]
+    public class UnitTest
+    {
+        readonly Assembly assemby = Assembly.GetAssembly(typeof(UnitTest));
+        private string testSolutionDirectory;
+
+        /// <summary>
+        /// SetUp
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            testSolutionDirectory = GetTestSolutionDirectory();
+        }
+
+        /// <summary>
+        /// TearDown
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+        }
+
+        /// <summary>
+        /// Run Test when the solution has dependencies and doesn't have BOM.
+        /// </summary>
+        [Test]
+        public void Run()
+        {
+            var baseSolution = Path.Combine(testSolutionDirectory, "ExampleProject.sln");
+            var processedSolution = Path.Combine(testSolutionDirectory, "ExampleProjectProcessed.sln");
+            var tempSolution = Path.Combine(testSolutionDirectory, "ExampleProjectTemp.sln");
+
+            if (File.Exists(tempSolution))
+            {
+                File.Delete(tempSolution);
+            }
+            File.Copy(baseSolution, tempSolution);
+            Parser.SetStartupProject(tempSolution, "ExampleProject");
+
+            FileAssert.AreEqual(processedSolution, tempSolution);
+
+            File.Delete(tempSolution);
+        }
+
+
+        /// <summary>
+        /// Run Test when the solution has dependencies and has BOM.
+        /// </summary>
+        [Test]
+        public void RunWithBOM()
+        {
+            var baseSolution = Path.Combine(testSolutionDirectory, "ExampleProjectBOM.sln");
+            var processedSolution = Path.Combine(testSolutionDirectory, "ExampleProjectProcessedBOM.sln");
+            var tempSolution = Path.Combine(testSolutionDirectory, "ExampleProjectTemp.sln");
+
+            if (File.Exists(tempSolution))
+            {
+                File.Delete(tempSolution);
+            }
+            File.Copy(baseSolution, tempSolution);
+            Parser.SetStartupProject(tempSolution, "ExampleProject");
+
+            FileAssert.AreEqual(processedSolution, tempSolution);
+
+            File.Delete(tempSolution);
+        }
+
+        /// <summary>
+        /// Get the Directory of the Assemby
+        /// </summary>
+        /// <returns></returns>
+        private string GetAssembyDirectory()
+        {
+            var assembyPath = this.assemby.Location;
+            var assembyDirecctory = Path.GetDirectoryName(assembyPath);
+            return assembyDirecctory;
+        }
+
+        /// <summary>
+        /// Get the Directory of test solution
+        /// </summary>
+        /// <returns></returns>
+        private string GetTestSolutionDirectory()
+        {
+            var testSolutionDirecotry = Path.GetFullPath(Path.Combine(GetAssembyDirectory(), @"..\..\tests\data\ExampleProject"));
+            return testSolutionDirecotry;
+        }
+    }
+}

--- a/tests/data/ExampleProject/ExampleLibrary/ExampleLibrary.vcxproj
+++ b/tests/data/ExampleProject/ExampleLibrary/ExampleLibrary.vcxproj
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Library.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Library.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ExampleLibrary</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/data/ExampleProject/ExampleLibrary/ExampleLibrary.vcxproj.filters
+++ b/tests/data/ExampleProject/ExampleLibrary/ExampleLibrary.vcxproj.filters
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="Library.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Library.h" />
+  </ItemGroup>
+</Project>

--- a/tests/data/ExampleProject/ExampleLibrary/Library.cpp
+++ b/tests/data/ExampleProject/ExampleLibrary/Library.cpp
@@ -1,0 +1,6 @@
+#include "Library.h"
+
+int Add(int a, int b)
+{
+	return a + b;
+}

--- a/tests/data/ExampleProject/ExampleLibrary/Library.h
+++ b/tests/data/ExampleProject/ExampleLibrary/Library.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int Add(int a, int b);

--- a/tests/data/ExampleProject/ExampleProject.sln
+++ b/tests/data/ExampleProject/ExampleProject.sln
@@ -1,0 +1,41 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleLibrary", "ExampleLibrary\ExampleLibrary.vcxproj", "{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleProject", "ExampleProject\ExampleProject.vcxproj", "{A63A0959-2EED-46D4-8E0B-3FE4D545E156}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82} = {7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.ActiveCfg = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.Build.0 = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.ActiveCfg = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.Build.0 = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.ActiveCfg = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.Build.0 = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.ActiveCfg = Release|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.Build.0 = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.ActiveCfg = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.Build.0 = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.ActiveCfg = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.Build.0 = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.ActiveCfg = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.Build.0 = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.ActiveCfg = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/data/ExampleProject/ExampleProject/ExampleProject.vcxproj
+++ b/tests/data/ExampleProject/ExampleProject/ExampleProject.vcxproj
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{A63A0959-2EED-46D4-8E0B-3FE4D545E156}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>ExampleProject</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../ExampleLibrary</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExampleLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../ExampleLibrary</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExampleLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../ExampleLibrary</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExampleLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>../ExampleLibrary</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ExampleLibrary.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/tests/data/ExampleProject/ExampleProject/ExampleProject.vcxproj.filters
+++ b/tests/data/ExampleProject/ExampleProject/ExampleProject.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+</Project>

--- a/tests/data/ExampleProject/ExampleProject/main.cpp
+++ b/tests/data/ExampleProject/ExampleProject/main.cpp
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include "Library.h"
+
+void main()
+{
+	printf("1 + 2 = %d\n", Add(1, 2));
+}

--- a/tests/data/ExampleProject/ExampleProjectBOM.sln
+++ b/tests/data/ExampleProject/ExampleProjectBOM.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleLibrary", "ExampleLibrary\ExampleLibrary.vcxproj", "{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleProject", "ExampleProject\ExampleProject.vcxproj", "{A63A0959-2EED-46D4-8E0B-3FE4D545E156}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82} = {7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.ActiveCfg = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.Build.0 = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.ActiveCfg = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.Build.0 = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.ActiveCfg = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.Build.0 = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.ActiveCfg = Release|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.Build.0 = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.ActiveCfg = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.Build.0 = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.ActiveCfg = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.Build.0 = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.ActiveCfg = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.Build.0 = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.ActiveCfg = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/data/ExampleProject/ExampleProjectProcessed.sln
+++ b/tests/data/ExampleProject/ExampleProjectProcessed.sln
@@ -1,0 +1,41 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleProject", "ExampleProject\ExampleProject.vcxproj", "{A63A0959-2EED-46D4-8E0B-3FE4D545E156}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82} = {7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleLibrary", "ExampleLibrary\ExampleLibrary.vcxproj", "{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.ActiveCfg = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.Build.0 = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.ActiveCfg = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.Build.0 = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.ActiveCfg = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.Build.0 = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.ActiveCfg = Release|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.Build.0 = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.ActiveCfg = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.Build.0 = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.ActiveCfg = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.Build.0 = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.ActiveCfg = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.Build.0 = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.ActiveCfg = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/data/ExampleProject/ExampleProjectProcessedBOM.sln
+++ b/tests/data/ExampleProject/ExampleProjectProcessedBOM.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.7
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleProject", "ExampleProject\ExampleProject.vcxproj", "{A63A0959-2EED-46D4-8E0B-3FE4D545E156}"
+	ProjectSection(ProjectDependencies) = postProject
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82} = {7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ExampleLibrary", "ExampleLibrary\ExampleLibrary.vcxproj", "{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.ActiveCfg = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x64.Build.0 = Debug|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.ActiveCfg = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Debug|x86.Build.0 = Debug|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.ActiveCfg = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x64.Build.0 = Release|x64
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.ActiveCfg = Release|Win32
+		{A63A0959-2EED-46D4-8E0B-3FE4D545E156}.Release|x86.Build.0 = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.ActiveCfg = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x64.Build.0 = Debug|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.ActiveCfg = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Debug|x86.Build.0 = Debug|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.ActiveCfg = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x64.Build.0 = Release|x64
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.ActiveCfg = Release|Win32
+		{7C961FE3-7761-4E1D-B533-4FD5F6D1AC82}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This pull request implements to a unittest for bug #6 

#7 will add VS2017 projects and solution. But it was not needed.
VS2017 can handle VS2013 projects. So I reimplement the tests for VS2013.

ExampleProject is a test data for the bug.
